### PR TITLE
fix: guard cargo env and java_home in shell startup

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -25,8 +25,10 @@ export PATH="$HOME/.nodenv/bin:$PATH"
 eval "$(nodenv init - --no-rehash)"
 
 # java
-export JAVA_HOME=`/usr/libexec/java_home -v 11`
-export PATH="$PATH:${JAVA_HOME}/bin"
+if /usr/libexec/java_home -v 11 >/dev/null 2>&1; then
+  export JAVA_HOME=`/usr/libexec/java_home -v 11`
+  export PATH="$PATH:${JAVA_HOME}/bin"
+fi
 
 # added by Snowflake SnowSQL installer v1.2
 export PATH=/Applications/SnowSQL.app/Contents/MacOS:$PATH

--- a/.zshenv
+++ b/.zshenv
@@ -65,4 +65,6 @@ if [ -f "$ZHOMEDIR/.zshenv.local" ]; then
   source "$ZHOMEDIR/.zshenv.local"
 fi
 
-. "$HOME/.cargo/env"
+if [ -f "$HOME/.cargo/env" ]; then
+  . "$HOME/.cargo/env"
+fi


### PR DESCRIPTION
## 概要
ログイン時に毎回出ていた以下のエラーを解消する。

```
~/.zshenv:.:68: no such file or directory: ~/.cargo/env
The operation couldn't be completed. Unable to locate a Java Runtime.
```

## 変更内容
- **`.zshenv`** — `~/.cargo/env` が存在する時だけ source する（Cargo 未インストール環境でのエラー回避）
- **`.zprofile`** — `/usr/libexec/java_home -v 11` が成功した時だけ `JAVA_HOME` / `PATH` を設定する（Java 11 未インストール環境でのエラー回避）

将来 Cargo / Java 11 をインストールすれば、ガードを通って従来どおり動作する。

## 確認
- `zsh -l -c 'echo OK'` がエラーなく `OK` を出力することを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)